### PR TITLE
Update Kubernetes version

### DIFF
--- a/source/sections/getting-started/07-version-information.md
+++ b/source/sections/getting-started/07-version-information.md
@@ -2,7 +2,7 @@
 Datica addresses vulnerabilities and security issues as they become publicly available. Kubernetes upgrades and deployment tooling updates happen on a quarterly basis (unless a security liability is present, in which case we would update as soon as possible). Below is a list of the current versions of software we run:
 
 - CoreOS: 1688.5.3
-- Kubernetes: 1.11.3
+- Kubernetes: 1.11.5
 - etcd: 3.2.18
 - Prometheus: 2.2.0
 - Elasticsearch: 6.1.2


### PR DESCRIPTION
During the flurry of work to upgrade all CKS clusters, we missed the step to update our documentation to reflect that all clusters have been upgraded to v1.11.5