### PR TITLE
Revert "Bump rack from 2.0.8 to 2.1.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.14.0)
     public_suffix (3.0.3)
-    rack (2.1.4)
+    rack (2.0.8)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)


### PR DESCRIPTION
Reverts daticahealth/cks-docs#74